### PR TITLE
feat: amazon adapter getUrl params option

### DIFF
--- a/adapters/amazon.js
+++ b/adapters/amazon.js
@@ -68,7 +68,9 @@ module.exports = config => {
     getUrl (name, options) {
       options = options || {}
       let operation = options.operation || 'getObject'
-      let params = {
+      let params = options.params || {}
+      params = {
+        ...params,
         Key: name
       }
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
I would like to add the ability to pass in custom parameters to the `getUrl` function. Currently we cannot change the default parameters through the options parameter. 

I would like to be able to do this to change the link expiry parameter from it's default of 15 minutes. 

See documentation [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getSignedUrl-property). 

Or snippet: 
```
Options Hash (params):

    Expires (Integer) — default: 900 —

    the number of seconds to expire the pre-signed URL operation in. Defaults to 15 minutes.
```