### PR TITLE
Feat: allow configuration of endpoint

### DIFF
--- a/adapters/amazon.js
+++ b/adapters/amazon.js
@@ -6,14 +6,19 @@ module.exports = config => {
   let client
   if (config.keyId && config.key) {
     // If we are provided with the AWS AccessKey and SecretAccessKey
-    client = new AWS.S3({
+    const s3Params = {
       accessKeyId: config.keyId,
       secretAccessKey: config.key,
       region: config.region,
       params: {
         Bucket: config.container
       }
-    })
+    }
+    // You can also specify an endpoint - for using a local s3 mimic
+    if (config.endpoint) {
+      s3Params.endpoint = config.endpoint
+    }
+    client = new AWS.S3(s3Params)
   } else {
     // If we need to infer our identity from the environment
     AWS.config.getCredentials(err => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mediasuite/cloud-storage",
-  "version": "0.6.3",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mediasuite/cloud-storage",
-      "version": "0.6.3",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.450.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mediasuite/cloud-storage",
   "description": "upload and download files from various providers",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
For locally testing with something that mimics S3 (for example localstack), you need the ability to specify an endpoint when creating the S3 client.